### PR TITLE
Additional constructors, type aliases

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,6 +17,8 @@ of 2D points by its extreme points. Functionality includes:
 
 ```@docs
 ConvexHull
+SConvexHull
+DConvexHull
 vertices
 num_vertices
 ```

--- a/src/PlanarConvexHulls.jl
+++ b/src/PlanarConvexHulls.jl
@@ -2,6 +2,8 @@ module PlanarConvexHulls
 
 export
     ConvexHull,
+    SConvexHull,
+    DConvexHull,
     CW,
     CCW,
     vertices,


### PR DESCRIPTION
Also add `SConvexHull` and `DConvexHull` as aliases for CCW statically-sized and dynamically sized `ConvexHull`s, for convenience.